### PR TITLE
Fix build errors in whd_gen generator

### DIFF
--- a/src/whd_gen/huffman.h
+++ b/src/whd_gen/huffman.h
@@ -10,6 +10,7 @@
 #include <queue>
 #include <memory>
 #include <iostream>
+#include <limits>
 
 template<typename S, typename C = std::less<S>, int N = 15> struct huffman_params {
     using symbol_type = S;

--- a/src/whd_gen/lodepng.cpp
+++ b/src/whd_gen/lodepng.cpp
@@ -33,6 +33,7 @@ Rename this file to lodepng.cpp to use it for C++, or to lodepng.c to use it for
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstdint>
 
 // graham ... this is slow but who cares... it does what we want - i.e. allows us to specify a destination palette not containing all the source colors
 #define NEAREST_NEIGHBOR

--- a/src/whd_gen/statsomizer.h
+++ b/src/whd_gen/statsomizer.h
@@ -6,6 +6,8 @@
 #pragma once
 #include <string>
 #include <algorithm>
+#include <limits>
+#include <cstdio>
 
 struct statsomizer {
     const std::string name;

--- a/src/whd_gen/wad.h
+++ b/src/whd_gen/wad.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 inline std::string to_lower(std::string x) {
     std::for_each(x.begin(), x.end(), [](char & c){
         c = ::tolower(c);
@@ -48,13 +49,15 @@ struct wad {
     }
 
     void keep_only(const std::set<int>& nums) {
-        for(auto it = lumps.begin(); it != lumps.end();) {
+        for (auto it = lumps.begin(); it != lumps.end();) {
             if (it->second.data.empty() || nums.find(it->first) != nums.end()) {
-//                printf("Keeping %s\n", it->second.name.c_str());
-                it++;
+                // Keep lump
+                ++it;
             } else {
+                // Remove lump and corresponding name without using invalid iterator
+                std::string name = it->second.name;
                 it = lumps.erase(it);
-                lump_names.erase(it->second.name);
+                lump_names.erase(name);
             }
         }
     }
@@ -93,7 +96,7 @@ struct wad {
     void update_lump(const lump& lump) {
         assert(lump.num>=0);
         if (to_lower(lumps[lump.num].name) != to_lower(lump.name)) {
-            auto it = lump_names.find(to_lower(name));
+            auto it = lump_names.find(to_lower(lump.name));
             if (it != lump_names.end()) {
                 lump_names.erase(it);
             }

--- a/src/whd_gen/whd_gen.cpp
+++ b/src/whd_gen/whd_gen.cpp
@@ -14,6 +14,7 @@
 #include <cstdarg>
 #include <array>
 #include <cmath>
+#include <limits>
 #include "doomdata.h"
 #include "whddata.h"
 #include "compress_mus.h"


### PR DESCRIPTION
## Summary
- add missing standard headers for integer limits and numeric limits
- correct lump removal and lookup logic in `wad` utilities
- ensure whd generator compiles on Linux

## Testing
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68b1019671ac8323866b76740ec42f6e